### PR TITLE
Remove double-quotes from table names when generating class names.

### DIFF
--- a/src/bin/GenerateSchema.vala
+++ b/src/bin/GenerateSchema.vala
@@ -392,7 +392,7 @@ namespace Almanna {
 		}
 
 		private string table_name_to_class_name( string table_name ) {
-			string[] parts = table_name.split("_");
+			string[] parts = table_name.replace("\"", "").split("_");
 			string class_name = "";
 			foreach ( string part in parts ) {
 				class_name = class_name + part.substring( 0, 1 ).up() + part.substring(1).down();


### PR DESCRIPTION
A very complex and comprehensive fix for issue #3

Everything else seems to be okay with the double quotes. If you remove them when they are read, then querying for columns breaks.
